### PR TITLE
Create main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,49 @@
+name: Build and deploy
+
+on:
+    push:
+        branches: [master]
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        permissions:
+          contents: write
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Prepare environment
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "20"
+
+            - run: npm install --global pnpm
+
+            - name: Install deps
+              run: pnpm m i
+
+            - name: Build plugin(s)
+              run: node ./build.mjs
+
+              # Foolproof feature:
+              # - Copies over README so that the root of the deployed website shows it
+              # - Changes 404 page to README so that you don't get lost while clicking links
+              # If you remove this step then you should probably remove the enable_jekyll option in the next one
+            - name: Copy additional files
+              run: |
+                  cp README.md dist/README.md
+                  printf -- "---\npermalink: /404.html\n---\n" > dist/404.md
+                  printf -- "> **Note:** You accessed a link that returned a 404, probably by clicking one of the plugin links. You're supposed to copy the link address and add it into Vendetta.\n\n" >> dist/404.md
+                  cat README.md >> dist/404.md
+
+              # Documentation: https://github.com/peaceiris/actions-gh-pages
+            - name: Deploy to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ./dist
+                  # Makes it so the md files in the previous step get processed by GitHub Pages
+                  enable_jekyll: true
+                  # This creates the CNAME file required to host GitHub Pages on a custom domain
+                  # cname: example.com


### PR DESCRIPTION
name: Build and deploy

on:
    push:
        branches: [master]

jobs:
    deploy:
        runs-on: ubuntu-latest
        permissions:
          contents: write

        steps:
            - uses: actions/checkout@v3

            - name: Prepare environment
              uses: actions/setup-node@v3
              with:
                  node-version: "20"

            - run: npm install --global pnpm

            - name: Install deps
              run: pnpm m i

            - name: Build plugin(s)
              run: node ./build.mjs

              # Foolproof feature:
              # - Copies over README so that the root of the deployed website shows it
              # - Changes 404 page to README so that you don't get lost while clicking links
              # If you remove this step then you should probably remove the enable_jekyll option in the next one
            - name: Copy additional files
              run: |
                  cp README.md dist/README.md
                  printf -- "---\npermalink: /404.html\n---\n" > dist/404.md
                  printf -- "> **Note:** You accessed a link that returned a 404, probably by clicking one of the plugin links. You're supposed to copy the link address and add it into Vendetta.\n\n" >> dist/404.md
                  cat README.md >> dist/404.md

              # Documentation: https://github.com/peaceiris/actions-gh-pages
            - name: Deploy to GitHub Pages
              uses: peaceiris/actions-gh-pages@v3
              with:
                  github_token: ${{ secrets.GITHUB_TOKEN }}
                  publish_dir: ./dist
                  # Makes it so the md files in the previous step get processed by GitHub Pages
                  enable_jekyll: true
                  # This creates the CNAME file required to host GitHub Pages on a custom domain
                  # cname: example.com